### PR TITLE
Fix some assorted issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/jest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI wrapper for recording jest tests",
   "bin": {
     "replay-jest": "bin/replay-jest"


### PR DESCRIPTION
Fixes a few problems I noticed while testing:

* By running replay-node with RECORD_REPLAY_DIRECTORY set to a temporary directory, we are currently downloading the node binary each time a test is recorded.  This launches the node binary directly to avoid this.
* Shows the ouput from recording if we didn't detect a test failure.
* Looks for the jest script via require.resolve instead of which, if possible.  This fixes a problem on babel where "which" returned another wrapper script that didn't work right with replay-node.